### PR TITLE
os_pickup_qssi_bt.bp is needed by QTI bt stack.

### DIFF
--- a/snippets/pixel-caf.xml
+++ b/snippets/pixel-caf.xml
@@ -56,6 +56,8 @@
     <linkfile src="os_pickup.mk" dest="vendor/nxp/opensource/pn5xx/Android.mk" />
     <linkfile src="os_pickup.bp" dest="vendor/nxp/opensource/sn100x/Android.bp" />
     <linkfile src="os_pickup.mk" dest="vendor/nxp/opensource/sn100x/Android.mk" />
+    <!-- add namespace for BT adv audio, as required for QTI BT stack -->
+    <linkfile src="os_pickup_qssi_bt.bp" dest="device/qcom/qssi/Android.bp" />
   </project>
   <project path="hardware/qcom-caf/msm8996/audio" name="hardware_qcom-caf_msm8996_audio" remote="pixel" />
   <project path="hardware/qcom-caf/msm8996-LA.UM.9.6.2.r1-04100-89xx.0/audio" name="hardware_qcom-caf_msm8996_audio" remote="pixel" revision="twelve-LA.UM.9.6.2.r1-04100-89xx.0" />

--- a/snippets/pixel.xml
+++ b/snippets/pixel.xml
@@ -7,7 +7,7 @@
           review="gerrit.pixelexperience.org" />
 
   <remote name="pixel-gitlab"
-          fetch="https://gitlab.com/PixelExperience"
+          fetch="https://gitlab.com/PixelExperience/twelve"
           revision="twelve" />
 
   <remote name="pixel-gitlab-self-hosted"

--- a/snippets/pixel.xml
+++ b/snippets/pixel.xml
@@ -43,7 +43,7 @@
   <project path="external/wpa_supplicant_8" name="external_wpa_supplicant_8" remote="pixel" />
 
   <!-- Framework repos -->
-  <project path="frameworks/av" name="frameworks_av" remote="raven" />
+  <project path="frameworks/av" name="frameworks_av" remote="pixel" />
   <project path="frameworks/base" name="frameworks_base" remote="raven" />
   <project path="frameworks/native" name="frameworks_native" remote="raven" />
   <project path="frameworks/opt/net/ims" name="frameworks_opt_net_ims" remote="pixel" />


### PR DESCRIPTION
Also aim to passing build normally.

```
FAILED: out/soong/build.ninja
cd "$(dirname "out/soong/.bootstrap/bin/soong_build")" && BUILDER="$PWD/$(basename "out/soong/.bootstrap/bin/soong_build")" && cd / && env -i "$BUILDER"     --top "$TOP"  
   --out "out/soong"     -n "out"     -d "out/soong/build.ninja.d"     -t -l out/.module_paths/Android.bp.list -globFile out/soong/.bootstrap/build-globs.ninja -o out/soon
g/build.ninja --available_env out/soong/soong.environment.available --used_env out/soong/soong.environment.used Android.bp
error: vendor/qcom/opensource/commonsys/system/bt/stack/Android.bp:2:9: module "device_qcom_qssi_Android_bpsoong_config_module_type_import_0xc0007dcc00": from: failed to o
pen "device/qcom/qssi/Android.bp": open /srv/media/WD/raven/device/qcom/qssi/Android.bp: no such file or directory
error: vendor/qcom/opensource/commonsys/system/bt/stack/Android.bp:8:1: unrecognized module type "bredr_vs_btadva_cc_defaults"
error: vendor/qcom/opensource/commonsys/system/bt/bta/Android.bp:8:1: unrecognized module type "bredr_vs_btadva_cc_defaults"
error: vendor/qcom/opensource/commonsys/system/bt/audio_hal_interface/Android.bp:8:1: unrecognized module type "bredr_vs_btadva_cc_defaults"
error: vendor/qcom/opensource/commonsys/system/bt/main/Android.bp:11:1: unrecognized module type "bredr_vs_btadva_cc_defaults"
error: vendor/qcom/opensource/commonsys/system/bt/btif/Android.bp:8:1: unrecognized module type "bredr_vs_btadva_cc_defaults"
error: vendor/qcom/opensource/commonsys/packages/apps/Bluetooth/Android.bp:11:1: unrecognized module type "bredr_vs_btadva_java_defaults"
error: vendor/qcom/opensource/commonsys/packages/apps/Bluetooth/jni/Android.bp:8:1: unrecognized module type "bredr_vs_btadva_cc_defaults"
```